### PR TITLE
Add `Game::query()` and `Game::command()` interface

### DIFF
--- a/pagurus_web/src/game.ts
+++ b/pagurus_web/src/game.ts
@@ -115,13 +115,13 @@ class Game {
 
     try {
       const nameBytesPtr = this.createWasmBytes(new TextEncoder().encode(name));
-      const result = (this.wasmInstance.exports.query as CallableFunction)(this.gameInstance, nameBytesPtr);
+      const result = (this.wasmInstance.exports.gameQuery as CallableFunction)(this.gameInstance, nameBytesPtr);
       const bytes = this.getWasmBytes(result);
       if (bytes[-1] === 0) {
         return bytes.subarray(0, bytes.length - 1);
       } else {
         const error = new TextDecoder("utf-8").decode(bytes.subarray(0, bytes.length - 1));
-        throw new Error(JSON.parse(error));
+        throw new Error(error);
       }
     } finally {
       this.systemRef.clearSystem();
@@ -134,14 +134,14 @@ class Game {
     try {
       const nameBytesPtr = this.createWasmBytes(new TextEncoder().encode(name));
       const dataBytesPtr = this.createWasmBytes(data);
-      const result = (this.wasmInstance.exports.command as CallableFunction)(
+      const result = (this.wasmInstance.exports.gameCommand as CallableFunction)(
         this.gameInstance,
         nameBytesPtr,
         dataBytesPtr
       );
       if (result !== 0) {
         const error = this.getWasmString(result);
-        throw new Error(JSON.parse(error));
+        throw new Error(error);
       }
     } finally {
       this.systemRef.clearSystem();

--- a/pagurus_web/src/game.ts
+++ b/pagurus_web/src/game.ts
@@ -110,6 +110,44 @@ class Game {
     }
   }
 
+  query(system: System, name: string): Uint8Array {
+    this.systemRef.setSystem(system);
+
+    try {
+      const nameBytesPtr = this.createWasmBytes(new TextEncoder().encode(name));
+      const result = (this.wasmInstance.exports.query as CallableFunction)(this.gameInstance, nameBytesPtr);
+      const bytes = this.getWasmBytes(result);
+      if (bytes[-1] === 0) {
+        return bytes.subarray(0, bytes.length - 1);
+      } else {
+        const error = new TextDecoder("utf-8").decode(bytes.subarray(0, bytes.length - 1));
+        throw new Error(JSON.parse(error));
+      }
+    } finally {
+      this.systemRef.clearSystem();
+    }
+  }
+
+  command(system: System, name: string, data: Uint8Array) {
+    this.systemRef.setSystem(system);
+
+    try {
+      const nameBytesPtr = this.createWasmBytes(new TextEncoder().encode(name));
+      const dataBytesPtr = this.createWasmBytes(data);
+      const result = (this.wasmInstance.exports.command as CallableFunction)(
+        this.gameInstance,
+        nameBytesPtr,
+        dataBytesPtr
+      );
+      if (result !== 0) {
+        const error = this.getWasmString(result);
+        throw new Error(JSON.parse(error));
+      }
+    } finally {
+      this.systemRef.clearSystem();
+    }
+  }
+
   private createWasmBytes(bytes: Uint8Array): number {
     const wasmBytesPtr = (this.wasmInstance.exports.memoryAllocateBytes as CallableFunction)(bytes.length) as number;
     const offset = (this.wasmInstance.exports.memoryBytesOffset as CallableFunction)(wasmBytesPtr) as number;
@@ -124,6 +162,16 @@ class Game {
       const len = (this.wasmInstance.exports.memoryBytesLen as CallableFunction)(wasmBytesPtr) as number;
       const bytes = new Uint8Array(this.memory.buffer, offset, len);
       return new TextDecoder("utf-8").decode(bytes);
+    } finally {
+      (this.wasmInstance.exports.memoryFreeBytes as CallableFunction)(wasmBytesPtr);
+    }
+  }
+
+  private getWasmBytes(wasmBytesPtr: number): Uint8Array {
+    try {
+      const offset = (this.wasmInstance.exports.memoryBytesOffset as CallableFunction)(wasmBytesPtr) as number;
+      const len = (this.wasmInstance.exports.memoryBytesLen as CallableFunction)(wasmBytesPtr) as number;
+      return new Uint8Array(this.memory.buffer, offset, len).slice();
     } finally {
       (this.wasmInstance.exports.memoryFreeBytes as CallableFunction)(wasmBytesPtr);
     }

--- a/pagurus_web/src/game.ts
+++ b/pagurus_web/src/game.ts
@@ -117,7 +117,7 @@ class Game {
       const nameBytesPtr = this.createWasmBytes(new TextEncoder().encode(name));
       const result = (this.wasmInstance.exports.gameQuery as CallableFunction)(this.gameInstance, nameBytesPtr);
       const bytes = this.getWasmBytes(result);
-      if (bytes[-1] === 0) {
+      if (bytes[bytes.length - 1] === 0) {
         return bytes.subarray(0, bytes.length - 1);
       } else {
         const error = new TextDecoder("utf-8").decode(bytes.subarray(0, bytes.length - 1));

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -30,6 +30,20 @@ pub trait System {
 pub trait Game<S: System> {
     fn initialize(&mut self, system: &mut S) -> Result<()>;
     fn handle_event(&mut self, system: &mut S, event: Event) -> Result<bool>;
+
+    #[allow(unused_variables)]
+    fn query(&mut self, system: &mut S, name: &str) -> Result<Vec<u8>> {
+        Err(crate::failure::Failure::new(format!(
+            "unknown query: {name:?}"
+        )))
+    }
+
+    #[allow(unused_variables)]
+    fn command(&mut self, system: &mut S, name: &str, data: &[u8]) -> Result<()> {
+        Err(crate::failure::Failure::new(format!(
+            "unknown command: {name:?}"
+        )))
+    }
 }
 
 #[derive(


### PR DESCRIPTION
This PR adds two methods to the `Game` trait to interact with games at runtime.